### PR TITLE
Get `package gstreamer-1.0` working on branch `meson-1.10`

### DIFF
--- a/packages/gstreamer-1.0-codecs.package
+++ b/packages/gstreamer-1.0-codecs.package
@@ -12,7 +12,7 @@ class Package(custom.GStreamer, package.Package):
 
     files = ['flac:libs', 'libkate:libs', 'libdv:libs',
             'libogg:libs', 'schroedinger:libs', 'speex:libs',
-            'libtheora:libs', 'wavpack:libs', 'libvpx:libs',
+            'libtheora:libs', 'wavpack:libs', #'libvpx:libs',
             'taglib:libs', 'opus:libs', 'libvorbis:libs',
             'openjpeg:libs', 'openh264:libs', 'spandsp:libs',
             'sbc:libs',

--- a/recipes/gst-plugins-bad-1.0.recipe
+++ b/recipes/gst-plugins-bad-1.0.recipe
@@ -227,6 +227,7 @@ class Recipe(custom.GStreamer):
             # Portability issues with MSVC
             self.files_plugins_codecs.remove('lib/gstreamer-1.0/libgstspandsp%(mext)s')
             self.files_plugins_effects.remove('lib/gstreamer-1.0/libgstsoundtouch%(mext)s')
+            self.files_plugins_effects.remove('lib/gstreamer-1.0/libgstwebrtcdsp%(mext)s')
 
         if self.config.target_platform != Platform.LINUX:
             self.configure_options += '--disable-gtk-doc '

--- a/recipes/gst-plugins-bad-1.0.recipe
+++ b/recipes/gst-plugins-bad-1.0.recipe
@@ -35,15 +35,15 @@ class Recipe(custom.GStreamer):
     files_lang = ['gst-plugins-bad-1.0']
 
     files_libs = ['libgstcodecparsers-1.0', 'libgstmpegts-1.0', 'libgsturidownloader-1.0',
-                  'libgstbasecamerabinsrc-1.0', 'libgstphotography-1.0',
-                  'libgstgl-1.0', 'libgstbadbase-1.0', 'libgstbadvideo-1.0',
-                  'libgstinsertbin-1.0', 'libgstadaptivedemux-1.0',
-                  'libgstplayer-1.0', 'libgstbadbase-1.0',
+                  'libgstbasecamerabinsrc-1.0', 'libgstphotography-1.0', #'libgstgl-1.0',
+                  'libgstbadbase-1.0', 'libgstbadvideo-1.0', 'libgstinsertbin-1.0',
+                  'libgstadaptivedemux-1.0', 'libgstplayer-1.0', 'libgstbadbase-1.0',
                   'libgstbadaudio-1.0', 'libgstbadvideo-1.0']
 
     files_plugins_devel = [
-        'include/gstreamer-1.0/gst/gl',
-        'lib/gstreamer-1.0/include/gst/gl',
+        # The GL library is currently not built with Meson
+        #'include/gstreamer-1.0/gst/gl',
+        #'lib/gstreamer-1.0/include/gst/gl',
         'include/gstreamer-1.0/gst/mpegts',
         'include/gstreamer-1.0/gst/player',
         'include/gstreamer-1.0/gst/base',
@@ -54,7 +54,7 @@ class Recipe(custom.GStreamer):
         'include/gstreamer-1.0/gst/insertbin',
         'include/gstreamer-1.0/gst/interfaces',
         'lib/pkgconfig/gstreamer-plugins-bad-1.0.pc',
-        'lib/pkgconfig/gstreamer-gl-1.0.pc',
+        #'lib/pkgconfig/gstreamer-gl-1.0.pc',
         'lib/pkgconfig/gstreamer-mpegts-1.0.pc',
         'lib/pkgconfig/gstreamer-player-1.0.pc',
         'lib/pkgconfig/gstreamer-bad-base-1.0.pc',
@@ -178,30 +178,27 @@ class Recipe(custom.GStreamer):
             ]
 
     platform_files_plugins_sys = {
+             # FIXME: Meson doesn't build this yet
+             #'lib/gstreamer-1.0/libgstopengl%(mext)s',
         Platform.LINUX: [
              'lib/gstreamer-1.0/libgstshm%(mext)s',
-             'lib/gstreamer-1.0/libgstopengl%(mext)s',
              'lib/gstreamer-1.0/libgstdecklink%(mext)s',
             ],
         Platform.WINDOWS: [
              'lib/gstreamer-1.0/libgstd3dvideosink%(mext)s',
              'lib/gstreamer-1.0/libgstwasapi%(mext)s',
-             'lib/gstreamer-1.0/libgstopengl%(mext)s'
             ],
         Platform.DARWIN: [
              'lib/gstreamer-1.0/libgstapplemedia%(mext)s',
              'lib/gstreamer-1.0/libgstshm%(mext)s',
-             'lib/gstreamer-1.0/libgstopengl%(mext)s',
              'lib/gstreamer-1.0/libgstdecklink%(mext)s',
             ],
         Platform.IOS: [
              'lib/gstreamer-1.0/libgstapplemedia%(mext)s',
              'lib/gstreamer-1.0/libgstshm%(mext)s',
-             'lib/gstreamer-1.0/libgstopengl%(mext)s'
             ],
         Platform.ANDROID: [
              'lib/gstreamer-1.0/libgstopensles%(mext)s',
-             'lib/gstreamer-1.0/libgstopengl%(mext)s'
             ]
     }
     files_typelibs = [

--- a/recipes/gst-plugins-good-1.0.recipe
+++ b/recipes/gst-plugins-good-1.0.recipe
@@ -51,7 +51,7 @@ class Recipe(custom.GStreamer):
              'lib/gstreamer-1.0/libgstaudioparsers%(mext)s',
              'lib/gstreamer-1.0/libgstauparse%(mext)s',
              'lib/gstreamer-1.0/libgstavi%(mext)s',
-             'lib/gstreamer-1.0/libgstdv%(mext)s',
+             #'lib/gstreamer-1.0/libgstdv%(mext)s',
              'lib/gstreamer-1.0/libgstflac%(mext)s',
              'lib/gstreamer-1.0/libgstflv%(mext)s',
              'lib/gstreamer-1.0/libgstflxdec%(mext)s',
@@ -64,7 +64,7 @@ class Recipe(custom.GStreamer):
              'lib/gstreamer-1.0/libgstmultipart%(mext)s',
              'lib/gstreamer-1.0/libgstpng%(mext)s',
              'lib/gstreamer-1.0/libgstspeex%(mext)s',
-             'lib/gstreamer-1.0/libgsttaglib%(mext)s',
+             #'lib/gstreamer-1.0/libgsttaglib%(mext)s',
              'lib/gstreamer-1.0/libgstvpx%(mext)s',
              'lib/gstreamer-1.0/libgstwavenc%(mext)s',
              'lib/gstreamer-1.0/libgstwavpack%(mext)s',
@@ -130,6 +130,10 @@ class Recipe(custom.GStreamer):
             self.files_plugins_sys += ['lib/gstreamer-1.0/libgstpulse%(mext)s']
         else:
             self.configure_options += ' --disable-pulse'
+
+        if self.config.variants.visualstudio:
+            # Needs git master of libvpx which has proper MSVC support
+            self.files_plugins_codecs.remove('lib/gstreamer-1.0/libgstvpx%(mext)s')
 
         if self.config.variants.nodebug:
             self.append_env['CFLAGS'] += ' -DGST_LEVEL_MAX=GST_LEVEL_FIXME'

--- a/recipes/gst-plugins-good-1.0.recipe
+++ b/recipes/gst-plugins-good-1.0.recipe
@@ -133,6 +133,7 @@ class Recipe(custom.GStreamer):
 
         if self.config.variants.visualstudio:
             # Needs git master of libvpx which has proper MSVC support
+            self.deps.remove('libvpx')
             self.files_plugins_codecs.remove('lib/gstreamer-1.0/libgstvpx%(mext)s')
 
         if self.config.variants.nodebug:


### PR DESCRIPTION
Small changes (most ported from `meson-1.8`) disabling some things that aren't built on Windows.

With these changes `python2 cerbero-uninstalled -c config/win64-mixed-msvc.cbc package gstreamer-1.0` generates the desired `.msi`s (although it still has some warnings and I haven't tested said MSIs).