### PR TITLE
cerbero: Implement selecting of build type via a command-line argument

### DIFF
--- a/cerbero/commands/__init__.py
+++ b/cerbero/commands/__init__.py
@@ -17,7 +17,7 @@
 # Boston, MA 02111-1307, USA.
 
 
-__all__ = ['Command', 'register_command', 'run']
+__all__ = ['Command', 'register_command', 'run', 'set_buildtype']
 
 
 from cerbero.errors import FatalError
@@ -76,3 +76,26 @@ def run(command, config, args):
         raise FatalError(_('command not found'))
 
     return _commands[command].run(config, args)
+
+def set_buildtype(config, buildtype):
+    msg = 'Build type is '
+    if buildtype == 'debug':
+        msg += 'debug'
+        setattr(config.variants, 'debug', True)
+        setattr(config.variants, 'nodebug', False)
+    elif buildtype == 'release':
+        msg += 'release'
+        setattr(config.variants, 'debug', False)
+        setattr(config.variants, 'nodebug', True)
+    elif buildtype == 'debugoptimized':
+        msg += 'debugoptimized'
+        setattr(config.variants, 'debug', None)
+        setattr(config.variants, 'nodebug', None)
+    else:
+        if config.variants.debug:
+            msg += 'debug (configuration)'
+        elif config.variants.nodebug:
+            msg += 'release (configuration)'
+        else:
+            msg += 'debugoptimized (default)'
+    m.message(msg)

--- a/cerbero/commands/build.py
+++ b/cerbero/commands/build.py
@@ -18,7 +18,7 @@
 
 
 #from cerbero.oven import Oven
-from cerbero.commands import Command, register_command
+from cerbero.commands import Command, register_command, set_buildtype
 from cerbero.build.cookbook import CookBook
 from cerbero.build.oven import Oven
 from cerbero.utils import _, N_, ArgparseArgument
@@ -32,6 +32,9 @@ class Build(Command):
             args = [
                 ArgparseArgument('recipe', nargs='*',
                     help=_('name of the recipe to build')),
+                ArgparseArgument('--buildtype', default=None,
+                    help=_('specifies the build type: "debug", "release" or '
+                           '"debugoptimized" (default)')),
                 ArgparseArgument('--missing-files', action='store_true',
                     default=False,
                     help=_('prints a list of files installed that are '
@@ -60,6 +63,7 @@ class Build(Command):
             self.force = args.force
         if self.no_deps is None:
             self.no_deps = args.no_deps
+        set_buildtype(config, args.buildtype)
         self.runargs(config, args.recipe, args.missing_files, self.force,
                      self.no_deps, dry_run=args.dry_run)
 

--- a/cerbero/commands/package.py
+++ b/cerbero/commands/package.py
@@ -19,7 +19,7 @@
 import os
 
 from cerbero.config import Platform
-from cerbero.commands import Command, register_command, build
+from cerbero.commands import Command, register_command, build, set_buildtype
 from cerbero.utils import _, N_, ArgparseArgument
 from cerbero.utils import messages as m
 from cerbero.errors import PackageNotFoundError, UsageError
@@ -44,6 +44,9 @@ class Package(Command):
                 default=None,
                 help=_('stores debug symbols from PDBs and binaries built with '
                        'MSVC at the specified location (default: no)')),
+            ArgparseArgument('--buildtype', default=None,
+                             help=_('specifies the build type: "debug", "release" '
+                             'or "debugoptimized" (default)')),
             ArgparseArgument('-t', '--tarball', action='store_true',
                 default=False,
                 help=_('Creates a tarball instead of a native package')),
@@ -71,6 +74,7 @@ class Package(Command):
 
     def run(self, config, args):
         self.ssp = None
+        set_buildtype(config, args.buildtype)
         self.store = PackagesStore(config)
         p = self.store.get_package(args.package[0])
 

--- a/recipes/zlib.recipe
+++ b/recipes/zlib.recipe
@@ -7,7 +7,7 @@ class Recipe(recipe.Recipe):
     version = '1.2.8'
     stype = SourceType.TARBALL
     btype = BuildType.MAKEFILE
-    url = 'http://zlib.net/zlib-1.2.8.tar.xz'
+    url = 'https://gstreamer.freedesktop.org/src/mirror/zlib-1.2.8.tar.gz'
     licenses = [License.BSD_like]
     add_host_build_target = False
     can_use_configure_cache = False


### PR DESCRIPTION
This also reports the currently-configured build type if
~/.cerbero/cerbero.cbc is used to set the debug variant.

Ported from the meson-1.8 branch. This was somehow missed in this
branch.

Note that 8d6511695c4433c66214fda6e36af0121f75b4e4 referred to the
`set_buildtype` function that this commit adds. That commit seems to
have been accidentally cherry-picked without this one.