### PR TITLE
Update bootstrap/windows.py regaring WindowsPath type instances

### DIFF
--- a/cerbero/bootstrap/windows.py
+++ b/cerbero/bootstrap/windows.py
@@ -187,8 +187,8 @@ class WindowsBootstrapper(BootstrapperBase):
         # to get some include dirs (which doesn't looks like a good idea).
         # If we only have the host-prefixed cpp, this problem is gone.
         if (self.msys_mingw_bindir / 'cpp.exe').is_file():
-            shutil.move(self.msys_mingw_bindir / 'cpp.exe',
-                        self.msys_mingw_bindir / 'cpp.exe.bck')
+            shutil.move(str(self.msys_mingw_bindir / 'cpp.exe'),
+                        str(self.msys_mingw_bindir / 'cpp.exe.bck'))
 
     def add_non_prefixed_strings(self):
         # libtool m4 macros uses non-prefixed 'strings' command. We need to


### PR DESCRIPTION
While running remove_mingw_cpp method, self.msys_mingw_bindir is of type pathlib.WindowsPath. At least in Python 3.5.4, shutil.move(...) expects its path arguments to be strings (inside shutil.move method, os.path.is_dir method is called, which is incompatible with the WindowsPath type. I had issues while running the bootstrap script. Making the proposed change resolved it.